### PR TITLE
Add citation metadata (CITATION.cff + How to cite)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'tokenize-uk: Ukrainian tokenizer'
+url: git@github.com:lang-uk/tokenize-uk
+type: software
+authors:
+- family-names: Chaplynskyi
+  given-names: Dmytro
+  orcid: https://orcid.org/0009-0000-0869-0999
+- name: lang-uk
+license: MIT
+repository-code: git@github.com:lang-uk/tokenize-uk
+references:
+- type: conference-paper
+  title: 'Introducing UberText 2.0: A Corpus of Modern Ukrainian at Scale'
+  authors:
+  - family-names: Chaplynskyi
+    given-names: Dmytro
+    orcid: https://orcid.org/0009-0000-0869-0999
+  collection-title: Proceedings of the Second Ukrainian Natural Language Processing Workshop (UNLP)
+  collection-type: proceedings
+  publisher:
+    name: Association for Computational Linguistics
+  conference:
+    name: Proceedings of the Second Ukrainian Natural Language Processing Workshop (UNLP)
+  year: 2023
+  month: 5
+  start: 1
+  end: 10
+  url: https://aclanthology.org/2023.unlp-1.1/
+  doi: 10.18653/v1/2023.unlp-1.1

--- a/README.md
+++ b/README.md
@@ -130,3 +130,27 @@ Reproduce with `scripts/benchmark.py` (see `docs/design.md`).
   behind the sentence layer
 
 MIT licensed.
+
+<!-- citekit:start -->
+## Як цитувати
+
+Якщо ви використовуєте **tokenize-uk: Ukrainian tokenizer**, будь ласка, процитуйте статтю, а не посилання на репозиторій — це єдиний спосіб, у який внесок стає видимим у наукометрії.
+
+> Chaplynskyi, D. (2023). Introducing UberText 2.0: A Corpus of Modern Ukrainian at Scale. In Proceedings of the Second Ukrainian Natural Language Processing Workshop (UNLP), pages 1–10. Association for Computational Linguistics. https://doi.org/10.18653/v1/2023.unlp-1.1
+
+```bibtex
+@inproceedings{chaplynskyi-2023-introducing,
+    title     = "Introducing {U}ber{T}ext 2.0: A Corpus of {M}odern {U}krainian at Scale",
+    author    = "Chaplynskyi, Dmytro",
+    editor    = "Romanyshyn, Mariana",
+    booktitle = "Proceedings of the Second Ukrainian Natural Language Processing Workshop (UNLP)",
+    month     = may,
+    year      = "2023",
+    address   = "Dubrovnik, Croatia",
+    publisher = "Association for Computational Linguistics",
+    url       = "https://aclanthology.org/2023.unlp-1.1/",
+    doi       = "10.18653/v1/2023.unlp-1.1",
+    pages     = "1--10"
+}
+```
+<!-- citekit:end -->


### PR DESCRIPTION
Adds the citation metadata this repository has been missing.

- `CITATION.cff` in the root, so GitHub renders a **Cite this repository**
  button that exports BibTeX and APA on demand.
- A **How to cite** section in the README pointing at the peer-reviewed paper
  that describes this resource, rather than leaving people to link the repo URL.

Both files are generated from a single manifest, so they stay consistent across
the org and can be regenerated when a paper gains a DOI or an arXiv ID.
